### PR TITLE
format_md_to_txt

### DIFF
--- a/RAG/utils.py
+++ b/RAG/utils.py
@@ -17,6 +17,9 @@ import html2text
 import json
 from tqdm import tqdm
 import tiktoken
+from bs4 import BeautifulSoup
+import re
+
 enc = tiktoken.get_encoding("cl100k_base")
 
 
@@ -112,10 +115,11 @@ class ReadFiles:
         with open(file_path, 'r', encoding='utf-8') as file:
             md_text = file.read()
             html_text = markdown.markdown(md_text)
-            # 从HTML中提取纯文本
-            text_maker = html2text.HTML2Text()
-            text_maker.ignore_links = True
-            text = text_maker.handle(html_text)
+            # 使用BeautifulSoup从HTML中提取纯文本
+            soup = BeautifulSoup(html_text, 'html.parser')
+            plain_text = soup.get_text()
+            # 使用正则表达式移除网址链接
+            text = re.sub(r'http\S+', '', plain_text) 
             return text
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ PyPDF2
 markdown
 html2text
 tiktoken
+beautifulsoup4


### PR DESCRIPTION
# 修复的问题
## 问题代码
```
  # 从HTML中提取纯文本
  text_maker = html2text.HTML2Text()    
  text_maker.ignore_links = True
  text = text_maker.handle(html_text)   # HTML2Text函数是将HTML转换为Markdown格式的文本，不是纯文本
```

## debug 效果示意： text 还是markdown格式，不是纯文本
![328d6a7a3863139c9604c1f116a34af](https://github.com/KMnO4-zx/TinyRAG/assets/3361335/e8dfc62c-2a1a-4484-b662-26a4a5679f1e)


## 修复方案及代码
```
# 将问题代码替换成：
# 使用BeautifulSoup从HTML中提取纯文本
soup = BeautifulSoup(html_text, 'html.parser')
plain_text = soup.get_text()
# 使用正则表达式移除网址链接
text = re.sub(r'http\S+', '', plain_text) 
```

## 修复效果
![image](https://github.com/KMnO4-zx/TinyRAG/assets/3361335/8023b2f6-ba62-4b82-881a-19f926c155d5)
