### PR TITLE
bugfix: vector.query没有"model"参数, 应改为EmbeddingModel

### DIFF
--- a/example.py
+++ b/example.py
@@ -15,7 +15,7 @@ from RAG.Embeddings import JinaEmbedding, ZhipuEmbedding
 
 # question = '正向扫描的原理是什么？'
 
-# content = vector.query(question, model='zhipu', k=1)[0]
+# content = vector.query(question, EmbeddingModel=embedding, k=1)[0]
 # chat = OpenAIChat(model='gpt-3.5-turbo-1106')
 # print(chat.chat(question, [], content))
 


### PR DESCRIPTION
在VecterStore的query方法中没有定义model参数，故应该改为 EmbeddingModel，修改后已顺利运行。

另外：
clone代码到本地之后，我创建了".env"文件并配置了自己的API key，然后尝试运行example.py，里面的“保存数据库之后”的case无法跑起来，原因应该是由于embedding阶段转换的向量维度与zhipu 这个embedding不匹配（storage 中保存的向量维度是768，zhipu embedding 转换的维度是1024，故余弦相似度无法计算），我自己重新生成一下数据库就可以跑起来了。